### PR TITLE
Add simple release job for Dashboard

### DIFF
--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -8,6 +8,7 @@ on:
       - "README.md"
     branches:
       - main
+      - "release-*"
 
 jobs:
   build-push:

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -1,0 +1,37 @@
+name: Make release
+
+# Required secrets:
+# GH_PAT - GitHub username with personal access token with permissions to make commits to repository, must be in format: "<username>:<PAT>"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version in SemVer (e.g. '0.5.0')
+        required: true
+
+jobs:
+  make-release:
+    name: Make release
+    runs-on: ubuntu-latest
+    environment: Release
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Setup Git credentials
+        # Replacing the GH Action token with PAT is required to trigger the branch-build workflow on a commit:
+        # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
+        run: |
+          git remote remove origin
+          git remote add origin https://${{secrets.GH_PAT}}@github.com/${{github.repository}}.git
+          git config --global user.email "bot@capact.io"
+          git config --global user.name "Capact Bot"
+      - name: Make release commit
+        env:
+          RELEASE_VERSION: "${{ github.event.inputs.version }}"
+          RUNNER_IMAGES_TAG: "${{ github.event.inputs.runner_image_tag }}"
+        run: ./scripts/make-release.sh

--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+[ -z "${RELEASE_VERSION}" ] && echo "Need to set RELEASE_VERSION" && exit 1;
+
+SOURCE_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+RELEASE_VERSION_MAJOR_MINOR="$(echo "${RELEASE_VERSION}" | sed -E 's/([0-9]+\.[0-9])\.[0-9]/\1/g')"
+RELEASE_BRANCH="release-${RELEASE_VERSION_MAJOR_MINOR}"
+
+main() {
+  git tag "v${RELEASE_VERSION}"
+  git push origin "v${RELEASE_VERSION}"
+
+  if [ "${RELEASE_BRANCH}" != "${SOURCE_BRANCH}" ]; then
+    git checkout -B "${RELEASE_BRANCH}"
+    git push origin "${RELEASE_BRANCH}"
+  fi
+}
+
+main


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Add simple release job for Dashboard

This job simply pushes new `x.y.z` tag and `relase-x.y` branch (if necessary).

Documentation will be done in a separate PR to `website` repo after 0.6.0 release to make sure I covered all changes to our release pipelines.

## Testing

See the example runs: 
- new minor release: https://github.com/pkosiec/dashboard/actions/runs/1750966741
- new patch release: https://github.com/pkosiec/dashboard/actions/runs/1750979217

## Related issue(s)

See https://github.com/capactio/capact/issues/600
